### PR TITLE
Provide a way to turn off adding typeIgnore for magic statement.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@vscode/lsp-notebook-concat",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vscode/lsp-notebook-concat",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "Notebook cell concatentation for language servers",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ export { isNotebookCell, getConcatDocumentRoot, RefreshNotebookEvent, NotebookCo
 
 export function createConverter(
     notebookHeaderGetter: (uri: vscodeUri.URI) => string,
-    platformGetter: () => string
+    platformGetter: () => string,
+    disableTypeIgnore = false
 ): NotebookConverter {
-    return new NotebookConverterImpl(notebookHeaderGetter, platformGetter);
+    return new NotebookConverterImpl(notebookHeaderGetter, platformGetter, disableTypeIgnore);
 }

--- a/src/notebookConcatDocument.ts
+++ b/src/notebookConcatDocument.ts
@@ -97,7 +97,10 @@ export class NotebookConcatDocument implements ITextDocument {
     private _lines: NotebookConcatLine[] = [];
     private _realLines: NotebookConcatLine[] = [];
 
-    constructor(public key: string, private readonly getNotebookHeader: (uri: vscodeUri.URI) => string) {}
+    constructor(
+        public key: string, 
+        private readonly getNotebookHeader: (uri: vscodeUri.URI) => string, 
+        private readonly _disableTypeIgnore = false) {}
 
     // Handles changes in the real cells and maps them to changes in the concat document.
     // This log expression is useful for debugging
@@ -743,7 +746,7 @@ export class NotebookConcatDocument implements ITextDocument {
         let spanOffset = 0;
         let lineOffset = 0;
         lines.forEach((l) => {
-            if (TypeIgnoreTransforms.find((transform) => transform.regex.test(l))) {
+            if (!this._disableTypeIgnore && TypeIgnoreTransforms.find((transform) => transform.regex.test(l))) {
                 // This means up to the current text needs to be turned into a span
                 spans.push(
                     this.createSpan(

--- a/src/notebookConverter.ts
+++ b/src/notebookConverter.ts
@@ -22,7 +22,10 @@ export class NotebookConverterImpl implements IDisposable {
 
     private mapOfConcatDocumentsWithCellUris = new Map<string, string[]>();
 
-    constructor(private getNotebookHeader: (uri: vscodeUri.URI) => string, private platformGetter: () => string) {}
+    constructor(
+        private getNotebookHeader: (uri: vscodeUri.URI) => string, 
+        private platformGetter: () => string, 
+        private disableTypeIgnore = false) {}
 
     private getDocumentKey(uri: vscodeUri.URI): string {
         if (uri.scheme === InteractiveInputScheme) {
@@ -937,7 +940,7 @@ export class NotebookConverterImpl implements IDisposable {
         const key = this.getDocumentKey(uri);
         let result = this.activeConcats.get(key);
         if (!result) {
-            result = new NotebookConcatDocument(key, this.getNotebookHeader);
+            result = new NotebookConcatDocument(key, this.getNotebookHeader, this.disableTypeIgnore);
             this.activeConcats.set(key, result);
         }
         return result;

--- a/src/test/suite/concatTextDocument.test.ts
+++ b/src/test/suite/concatTextDocument.test.ts
@@ -289,6 +289,38 @@ suite('concatTextDocument', () => {
         );
     });
 
+    test('Cell with magics/shell escape/await with typeIgnore off', () => {
+        withTestNotebook(
+            vscodeUri.URI.from({ scheme: 'vscode-notebook', path: 'test.ipynb' }),
+            [
+                [['await print(1)'], 'python', 'code', [], {}],
+                [['test'], 'markdown', 'markup', [], {}],
+                [['%foo = 2', 'print(foo)'], 'python', 'code', [], {}],
+                [['%%foo = 2', 'print(foo)'], 'python', 'code', [], {}],
+                [['!foo = 2', 'print(foo)'], 'python', 'code', [], {}]
+            ],
+            (uri: vscodeUri.URI, cells: ICell[]) => {
+                const concat = generateConcat(uri, cells, undefined, /*disableTypeIgnore*/ true);
+                assert.strictEqual(concat.lineCount, 9);
+                assert.strictEqual(concat.languageId, 'python');
+                assert.strictEqual(
+                    concat.getText(),
+                    [
+                        HeaderText,
+                        'await print(1)',
+                        '%foo = 2',
+                        'print(foo)',
+                        '%%foo = 2',
+                        'print(foo)',
+                        '!foo = 2',
+                        'print(foo)',
+                        ''
+                    ].join('\n')
+                );
+            }
+        );
+    });
+
     test('Edit a magic/shell/await', () => {
         withTestNotebook(
             vscodeUri.URI.from({ scheme: 'vscode-notebook', path: 'test.ipynb' }),

--- a/src/test/suite/helper.ts
+++ b/src/test/suite/helper.ts
@@ -52,8 +52,8 @@ export function withTestNotebook(
     callback(uri, mapped);
 }
 
-export function generateConcat(uri: vscodeUri.URI, cells: ICell[], extraCells?: ICell[]) {
-    const concat = new NotebookConcatDocument(uri.toString(), () => '');
+export function generateConcat(uri: vscodeUri.URI, cells: ICell[], extraCells?: ICell[], disableTypeIgnore = false) {
+    const concat = new NotebookConcatDocument(uri.toString(), () => '', disableTypeIgnore);
     const converter = (c: ICell) => {
         const result: protocol.DidOpenTextDocumentParams = {
             textDocument: {


### PR DESCRIPTION
disableTypeIgnore will let concat doc to leave magic statement as it is.